### PR TITLE
Remove pprint from requirements

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,3 @@
-pprint
 apted
 distance
 lxml


### PR DESCRIPTION
pprint is a native Python library that allows you to customize the formatting of your output. There is no need for adding it into the requirements.txt.

Moreover, trying to install it will lead to an error as pip is not able to find the pprint module.